### PR TITLE
🙈 Add Sandbox folder to GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -791,4 +791,6 @@ sysinfo.txt
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
 
-# End of https://www.toptal.com/developers/gitignore/api/rider,visualstudio,visualstudiocode,csharp,jetbrains+all,unity
+# Sandbox Files
+Assets/Scenes/Sandbox.meta
+Assets/Scenes/Sandbox/*


### PR DESCRIPTION
Github will now ignore sandbox scenes, allowing developers to freely modify their own sandbox scenes without having to continously discard them.
Closes #10 