### PR TITLE
🐛 Fix conflicting GUID

### DIFF
--- a/Assets/Art/PolygonAdventure/Materials/PolyAdventureTexture_01.mat.meta
+++ b/Assets/Art/PolygonAdventure/Materials/PolyAdventureTexture_01.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e14f95f95144b4646a6ad540286ad4e0
+guid: 83a374edfe97a544ea0e416ac0283422
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
## Content
The GUID of the materials folder and the material file were the same somehow.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->

### Updated
`Assets/Art/PolygonAdventure/Materials/PolyAdventureTexture_01.mat.meta` : Was updated with a new GUID.