### PR TITLE
✨ Added Damage Indicators

### DIFF
--- a/Assets/Prefabs/Units/Testing.meta
+++ b/Assets/Prefabs/Units/Testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 872fbc22632b2c2419fae0c1b8a31e74
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Units/Testing/Enemy - Sword - Damage Indicator Test.prefab
+++ b/Assets/Prefabs/Units/Testing/Enemy - Sword - Damage Indicator Test.prefab
@@ -1,0 +1,343 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1155881469209181120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5194477464975061471}
+  - component: {fileID: 6481274059436460527}
+  - component: {fileID: 1092766557517677463}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5194477464975061471
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1155881469209181120}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6660491040150389665}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 2, y: 3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6481274059436460527
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1155881469209181120}
+  m_CullTransparentMesh: 1
+--- !u!114 &1092766557517677463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1155881469209181120}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 100
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190335
+  m_fontColor: {r: 1, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 0.85
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 0.02
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 2.0206394, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3510862391467460104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6660491040150389665}
+  - component: {fileID: 1523048196451889897}
+  - component: {fileID: 5701033370185165548}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6660491040150389665
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3510862391467460104}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5194477464975061471}
+  m_Father: {fileID: 806901676227527311}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.1404, y: 2.3562014}
+  m_SizeDelta: {x: 2, y: 0.8798}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &1523048196451889897
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3510862391467460104}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &5701033370185165548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3510862391467460104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!1001 &4187433792297583364
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 999573447772925781, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208021283357203045, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      propertyPath: m_Name
+      value: Enemy - Sword Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6660491040150389665}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7208021283357203045, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 451435936747288547}
+  m_SourcePrefab: {fileID: 100100000, guid: cf82ee9dfbd2dac499b10241ae5997f6, type: 3}
+--- !u!4 &806901676227527311 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3543893195411210635, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4187433792297583364}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6779265387862907233 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7208021283357203045, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4187433792297583364}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &451435936747288547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6779265387862907233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 277addb430082df469dd5c5b3db84625, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _health: {fileID: 9194873884448341601}
+  _text: {fileID: 1092766557517677463}
+  _canvas: {fileID: 6660491040150389665}
+  _endColor: {r: 0, g: 0, b: 0, a: 0}
+  _movePosition: {x: 0, y: 2, z: 0}
+  _tweenDuration: 1
+--- !u!114 &9194873884448341601 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5009693618887359845, guid: cf82ee9dfbd2dac499b10241ae5997f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4187433792297583364}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6779265387862907233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ad5b2fe2daecbd4980215b4e0138bd6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Units/Testing/Enemy - Sword - Damage Indicator Test.prefab.meta
+++ b/Assets/Prefabs/Units/Testing/Enemy - Sword - Damage Indicator Test.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13d003cecf4b4e0409368a0f4ea7fc21
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Health/DamageIndicator.cs
+++ b/Assets/Scripts/Health/DamageIndicator.cs
@@ -1,0 +1,41 @@
+using DG.Tweening;
+using TMPro;
+using UnityEngine;
+
+namespace RogueApeStudio.Crusader.HealthSystem
+{
+    public class DamageIndicator : MonoBehaviour
+    {
+        [Header("Required Components")]
+        [SerializeField] private Health _health;
+        [SerializeField] private TextMeshProUGUI _text;
+        [SerializeField] private Transform _canvas;
+
+        [Header("Indicator Settings")]
+        [SerializeField] private Color _endColor;
+        [SerializeField, Tooltip("Keep Z at 0.")] private Vector3 _movePosition;
+        [SerializeField] private float _tweenDuration = .9f;
+
+        private void Start()
+        {
+            _health.OnDamage += HandleDamageTaken;
+        }
+
+        private void OnDestroy()
+        {
+            _health.OnDamage -= HandleDamageTaken;
+            DOTween.KillAll();
+            DOTween.Clear();
+        }
+
+        private void HandleDamageTaken(float damage)
+        {
+            var tmp = Instantiate(_text,_canvas,false);
+            tmp.text = damage.ToString();
+            tmp.enabled = true;
+            tmp.DOColor(_endColor, _tweenDuration);
+            tmp.transform.DOLocalMove(_movePosition, _tweenDuration);
+            Destroy(tmp.gameObject, _tweenDuration + .1f);
+        }
+    }
+}

--- a/Assets/Scripts/Health/DamageIndicator.cs.meta
+++ b/Assets/Scripts/Health/DamageIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 277addb430082df469dd5c5b3db84625
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Health/Health.cs
+++ b/Assets/Scripts/Health/Health.cs
@@ -9,7 +9,7 @@ namespace RogueApeStudio.Crusader.HealthSystem
 
         public event Action OnDeath;
         public event Action OnHeal;
-        public event Action OnDamage;
+        public event Action<float> OnDamage;
 
         #endregion
 
@@ -56,7 +56,7 @@ namespace RogueApeStudio.Crusader.HealthSystem
             }
             else
             {
-                OnDamage?.Invoke();
+                OnDamage?.Invoke(damage);
             }
         }
 

--- a/Assets/Scripts/Health/RogueApe.Crusader.HealthSystem.asmdef
+++ b/Assets/Scripts/Health/RogueApe.Crusader.HealthSystem.asmdef
@@ -1,7 +1,10 @@
 {
     "name": "RogueApeStudio.Crusader.HealthSystem",
     "rootNamespace": "RogueApeStudio.Crusader.HealthSystem",
-    "references": [],
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:65445bcbc0eee6544bda9f60f9afffba"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,


### PR DESCRIPTION
## Content

Adds a system for showcasing the damage done to an enemy.

Since the feature is still in testing, it does not exist on the main enemies just yet. (They'll also need some extra code to always face the camera, but that's for later).

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->
### Added
`Assets/Prefabs/Units/Testing/Enemy - Sword - Damage Indicator Test.prefab` : Was created.
`Assets/Scripts/Health/DamageIndicator.cs` : Was created, it handles all the code for the damage values.
`Assets/Prefabs/Units/Testing.meta` : Was created.

### Updated
`Health.cs` : Was updated, and now the `OnDamage` event sends the damage taken along with it.
`Assets/Scripts/Health/RogueApe.Crusader.HealthSystem.asmdef` : Was updated, to include DoTween.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Add Enemy - Sword - Damage Indicator to the scene.
2. Damage the enemy using the Health Script Hit.
3. Observe.

![DamageIndicators](https://github.com/Rogue-Ape-Studios/Crusader/assets/99728206/2bc29684-44cd-426f-864d-c1ad01f8c4f8)


<!-- If there is no issue, simply remove it. -->
While it does include the code for #67 , since the main gameplay loop is not done just yet, testing cannot be completed.