### PR TITLE
🐛 Fix dash direction with no input

### DIFF
--- a/Assets/Scripts/Player/Movement/PlayerController.cs
+++ b/Assets/Scripts/Player/Movement/PlayerController.cs
@@ -59,27 +59,12 @@ namespace RogueApeStudio.Crusader.Player.Movement
         {
             if (!_isDashing && _dashCooldownTimer <= 0 && _readInputs && !_animator.GetCurrentAnimatorStateInfo(0).IsName("PlayerDiveForward"))
             {
-                Vector2 inputDirection = _movementInput.ReadValue<Vector2>();
-                Vector3 dashDirection = Vector3.forward;
-
                 _dashCooldownTimer = _dashCooldown;
                 _isDashing = true;
                 _animator.SetTrigger("Dash");
                 SetReadInput(false);
 
-                if (inputDirection != Vector2.zero)
-                {
-                    dashDirection = new Vector3(inputDirection.x, 0f, inputDirection.y).normalized;
-                }
-                else
-                {
-                    if (_lastMovementDirection != Vector3.zero)
-                    {
-                        dashDirection = _lastMovementDirection.normalized;
-                    }
-                }
-
-                Vector3 dashForce = dashDirection * _dashSpeed;
+                Vector3 dashForce = _rb.transform.forward * _dashSpeed;
 
                 _rb.AddForce(dashForce, ForceMode.Impulse);
             }

--- a/Assets/Scripts/Player/Movement/PlayerController.cs
+++ b/Assets/Scripts/Player/Movement/PlayerController.cs
@@ -19,6 +19,7 @@ namespace RogueApeStudio.Crusader.Player.Movement
         private bool _readInputs = true;
 
         [SerializeField] private Rigidbody _rb;
+        [SerializeField] private Transform _transform;
         [SerializeField] private Animator _animator;
 
         [Header("Movement Options")]
@@ -64,7 +65,7 @@ namespace RogueApeStudio.Crusader.Player.Movement
                 _animator.SetTrigger("Dash");
                 SetReadInput(false);
 
-                Vector3 dashForce = _rb.transform.forward * _dashSpeed;
+                Vector3 dashForce = _transform.forward * _dashSpeed;
 
                 _rb.AddForce(dashForce, ForceMode.Impulse);
             }
@@ -98,7 +99,7 @@ namespace RogueApeStudio.Crusader.Player.Movement
         {
             if (_isDashing)
             {
-                _rb.transform.rotation = Quaternion.LookRotation(direction);
+                _transform.rotation = Quaternion.LookRotation(direction);
             }
             else 
             {
@@ -125,7 +126,7 @@ namespace RogueApeStudio.Crusader.Player.Movement
         public void AddForce(float force)
         {
             SetReadInput(false);
-            Vector3 forceDirection = _rb.transform.forward * force;
+            Vector3 forceDirection = _transform.forward * force;
             _rb.AddForce(forceDirection, ForceMode.Impulse);
         }
 


### PR DESCRIPTION
## Content

Player now dashes in the direction the character is looking when no input is detected.

## Changes

### Updated
`Assets/Scripts/Player/Movement/PlayerController.cs` : Was updated. logic to save last movement input was deleted to use vector3.forward.

## Testing

The feature / Bugfix can be testing by following these steps:

![DashDirectionFix](https://github.com/Rogue-Ape-Studios/Crusader/assets/90602424/5e39fc81-8c94-4828-bd04-25cfe271ea9d)

Closes #107 