### PR TITLE
🚑️ Health editor namespace

### DIFF
--- a/Assets/Scripts/Health/Editor/RogueApe.Crusader.HealthSystem.Editor.asmdef
+++ b/Assets/Scripts/Health/Editor/RogueApe.Crusader.HealthSystem.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:f7682a76ed81e8c49915bc28ca915c12"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Assets/Scripts/Items/BasePlayerConfig.cs
+++ b/Assets/Scripts/Items/BasePlayerConfig.cs
@@ -1,4 +1,3 @@
-using UnityEditor.EditorTools;
 using UnityEngine;
 
 namespace RogueApeStudio.Crusader.Items

--- a/Assets/Scripts/Spawn/Editor/RogueApe.Crusader.Spawn.Editor.asmdef
+++ b/Assets/Scripts/Spawn/Editor/RogueApe.Crusader.Spawn.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:8777e36ce92585c44a3f17a52392ae90"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Assets/Scripts/Spawn/Editor/SpawnManagerEditor.cs
+++ b/Assets/Scripts/Spawn/Editor/SpawnManagerEditor.cs
@@ -8,10 +8,12 @@ namespace RogueApeStudio.Crusader.Spawn.Editor
     public class SpawnManagerEditor : UnityEditor.Editor
     {
         private SpawnManager _spawnManager;
+        private Transform _spawnManagerTransform;
         private bool _enableEditorSettings;
         public override void OnInspectorGUI()
         {
             _spawnManager = target as SpawnManager;
+            _spawnManagerTransform = _spawnManager.transform;
 
             base.DrawDefaultInspector();
 
@@ -49,5 +51,6 @@ namespace RogueApeStudio.Crusader.Spawn.Editor
             _spawnManager.BeginTangent = EditorGUILayout.Vector3Field("Begin Tangent", _spawnManager.BeginTangent);
             _spawnManager.EndTangent = EditorGUILayout.Vector3Field("End Tangent", _spawnManager.EndTangent);
         }
+        
     }
 }

--- a/Assets/Scripts/Spawn/Editor/SpawnManagerEditor.cs
+++ b/Assets/Scripts/Spawn/Editor/SpawnManagerEditor.cs
@@ -8,12 +8,10 @@ namespace RogueApeStudio.Crusader.Spawn.Editor
     public class SpawnManagerEditor : UnityEditor.Editor
     {
         private SpawnManager _spawnManager;
-        private Transform _spawnManagerTransform;
         private bool _enableEditorSettings;
         public override void OnInspectorGUI()
         {
             _spawnManager = target as SpawnManager;
-            _spawnManagerTransform = _spawnManager.transform;
 
             base.DrawDefaultInspector();
 
@@ -51,6 +49,5 @@ namespace RogueApeStudio.Crusader.Spawn.Editor
             _spawnManager.BeginTangent = EditorGUILayout.Vector3Field("Begin Tangent", _spawnManager.BeginTangent);
             _spawnManager.EndTangent = EditorGUILayout.Vector3Field("End Tangent", _spawnManager.EndTangent);
         }
-        
     }
 }

--- a/Assets/Scripts/Spawn/SpawnManager.cs
+++ b/Assets/Scripts/Spawn/SpawnManager.cs
@@ -265,6 +265,10 @@ namespace RogueApeStudio.Crusader.Spawn
             return _spawnLocations[0].position;
         }
 
+        #endregion
+
+        #if UNITY_EDITOR
+
         private void OnDrawGizmos()
         {
             foreach (var spawns in _spawnLocations)
@@ -273,6 +277,6 @@ namespace RogueApeStudio.Crusader.Spawn
             }
         }
 
-        #endregion
+        #endif
     }
 }


### PR DESCRIPTION
## Content

This was due to the fact Unity was requested to build editor scripts for the release build.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->

### Updated
`Assets/Scripts/Health/Editor/RogueApe.Crusader.HealthSystem.Editor.asmdef` : Was updated, to only be included for the editor.
`Assets/Scripts/Items/BasePlayerConfig.cs` : Removed editor reference.
`Assets/Scripts/Spawn/Editor/RogueApe.Crusader.Spawn.Editor.asmdef` : Was updated, to only be included for the editor.
`Assets/Scripts/Spawn/SpawnManager.cs` : Was updated, added region to specify Editor Only.

## Testing

The Bugfix can be testing by following these steps:

1. Add the Entrance scene to the scenes to be included in the build.
2. Build the game.
3. Play the game.
4. 

![image](https://github.com/Rogue-Ape-Studios/Crusader/assets/99728206/070d2df1-037b-4fb3-8ce0-dddb52423399)

<!-- If there is no issue, simply remove it. -->
Closes #134