### PR TITLE
💄 Move the bezier curves to OnDrawGizmosSelected

### DIFF
--- a/Assets/Scripts/Spawn/SpawnManager.cs
+++ b/Assets/Scripts/Spawn/SpawnManager.cs
@@ -269,7 +269,7 @@ namespace RogueApeStudio.Crusader.Spawn
 
         #if UNITY_EDITOR
 
-        private void OnDrawGizmos()
+        private void OnDrawGizmosSelected()
         {
             foreach (var spawns in _spawnLocations)
             {


### PR DESCRIPTION
## Content
Changed the function, so the bezier curves only exist once the SpawnSystem is selected.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->
### Updated
`Assets/Scripts/Spawn/SpawnManager.cs` : Changed `OnDrawGizmos` to `OnDrawGizmosSelected`, to avoid the lines being permanent.

## Testing
The feature / Bugfix can be testing by following these steps:
1. View the SpawnSystem, no curves are visible.
2. Select the SpawnSystem, curves are visible.
