### PR TITLE
✨ Toggle mouse directional

### DIFF
--- a/Assets/Scripts/Player/Combat/BasicAttack.cs
+++ b/Assets/Scripts/Player/Combat/BasicAttack.cs
@@ -33,7 +33,7 @@ namespace RogueApeStudio.Crusader.Player.Combat
         [SerializeField] private int _comboCounter = 0;
         [SerializeField] private int _attackSpeed = 5;
         [SerializeField] private float _attackWindow = 0.5f;
-        [SerializeField] private bool _canAttack;
+        [SerializeField] private bool _canAttack = true;
         [SerializeField] private bool _windowCountdown = false;
 
         [Header("Sword Swings SFX")]

--- a/Assets/Scripts/Player/Combat/BasicAttack.cs
+++ b/Assets/Scripts/Player/Combat/BasicAttack.cs
@@ -16,6 +16,9 @@ namespace RogueApeStudio.Crusader.Player.Combat
         [SerializeField] private float _force = 10f;
         [SerializeField] private Rigidbody _rb;
 
+        [Header("Player preferences")]
+        [SerializeField] bool _cursorDirection = true;
+
         [Header("Raycast necessities")]
         [SerializeField] private Camera _cam;
         [SerializeField] private string[] _tags;
@@ -30,7 +33,7 @@ namespace RogueApeStudio.Crusader.Player.Combat
         [SerializeField] private int _comboCounter = 0;
         [SerializeField] private int _attackSpeed = 5;
         [SerializeField] private float _attackWindow = 0.5f;
-        [SerializeField] private bool _canAttack = true;
+        [SerializeField] private bool _canAttack;
         [SerializeField] private bool _windowCountdown = false;
 
         [Header("Sword Swings SFX")]
@@ -88,7 +91,7 @@ namespace RogueApeStudio.Crusader.Player.Combat
             _animator.Play(_animations[_comboCounter - 1].name);
             _delay = _animations[_comboCounter - 1].length / _attackSpeed;
             _attackWindow = 0.5f;
-            if (Keyboard.current != null)
+            if (Keyboard.current != null && _cursorDirection)
             {
                 Ray cameraRay = _cam.ScreenPointToRay(Mouse.current.position.ReadValue());
 


### PR DESCRIPTION
## Content

There is now a serializefield in the basic attack script, here you can toggle whether you want to attack with directional input or your cursor.

## Changes

### Updated
`Assets/Scripts/Player/Combat/BasicAttack.cs` : Was updated. A toggle has been added to change attack direction input.

## Testing

The feature / Bugfix can be testing by following these steps:

![afbeelding](https://github.com/Rogue-Ape-Studios/Crusader/assets/90602424/b0f29e1c-ee84-46eb-bdfc-50d4849093c4)

Closes #157 