### PR TITLE
✨ Knockback improvement

### DIFF
--- a/Assets/Scripts/Player/Abilities/WaveAbility.cs
+++ b/Assets/Scripts/Player/Abilities/WaveAbility.cs
@@ -78,13 +78,11 @@ namespace RogueApeStudio.Crusader.Player.Abilities
                 {
                     if (hitCollider.CompareTag("Enemy"))
                     {
-                        Vector3 knockbackDiraction = transform.position - hitCollider.transform.position;
-                        knockbackDiraction = knockbackDiraction.normalized;
-                        knockbackDiraction = new Vector3(knockbackDiraction.x, 0, knockbackDiraction.z);
-
-                        float force = (_knockbackForce + (1 / Vector3.Distance(transform.transform.position, hitCollider.transform.position) * 10));
-
-                        hitCollider.transform.GetComponent<Knockback>().AddKnockback(force, -knockbackDiraction);
+                        Vector3 knockbackDirection = transform.position - hitCollider.transform.position;
+                        knockbackDirection = knockbackDirection.normalized;
+                        knockbackDirection = new Vector3(knockbackDirection.x, 0, knockbackDirection.z);
+                                               
+                        hitCollider.transform.GetComponent<Knockback>().AddKnockback(_knockbackForce, -knockbackDirection);
                     }
                 }
                 StartCooldownAsync(_cancellationTokenSource.Token);

--- a/Assets/Scripts/Units/Knockback.cs
+++ b/Assets/Scripts/Units/Knockback.cs
@@ -18,6 +18,9 @@ namespace RogueApeStudio.Crusader.Units.Knockback
         [SerializeField] private Rigidbody _rb;
         [SerializeField] private Enemy _enemy;
 
+        [Header("Stun settings")]
+        [SerializeField] private float _stunDuration = 1f;
+
         private void Awake()
         {
             _cancellationTokenSource = new CancellationTokenSource();
@@ -49,7 +52,7 @@ namespace RogueApeStudio.Crusader.Units.Knockback
         {
             try
             {
-                await UniTask.WaitForSeconds(1, cancellationToken: token);
+                await UniTask.WaitForSeconds(_stunDuration, cancellationToken: token);
                 _rb.isKinematic = true;
                 _agent.enabled = true;
                 Physics.IgnoreLayerCollision(10, 10, false);


### PR DESCRIPTION
## Content

Change the way the knockback is calculated.
Values for wave ability should be 8 force, 4 radius.

## Changes

### Updated
`Assets/Scripts/Player/Abilities/WaveAbility.cs` : Was updated. Removed power fall off based on distance.
`Assets/Scripts/Units/Knockback.cs` : Was updated. Magic number was removed.
## Testing

The feature / Bugfix can be testing by following these steps:

![KnockbackChange](https://github.com/Rogue-Ape-Studios/Crusader/assets/90602424/f62990a0-7d72-4666-8203-6d3f3ce2d2a6)

Closes #162 