### PR TITLE
🐛 Fix player not being able to deal damage to enemies

### DIFF
--- a/Assets/Prefabs/Player/Player_1.prefab
+++ b/Assets/Prefabs/Player/Player_1.prefab
@@ -241,7 +241,7 @@ MonoBehaviour:
   - Enemy
   _applyKnockback: 1
   _force: 1
-  _playerStats: {fileID: 0}
+  _playerStats: {fileID: 11400000, guid: 17f906094abc5614e84ea397e706cbdd, type: 2}
 --- !u!23 &11393158695039202
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Entrance.unity
+++ b/Assets/Scenes/Levels/Entrance.unity
@@ -10032,6 +10032,12 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player_1
       objectReference: {fileID: 0}
+    - target: {fileID: 1910005954556340578, guid: 49b062202ce45074d8c05cdeda7786df,
+        type: 3}
+      propertyPath: _playerStats
+      value: 
+      objectReference: {fileID: 11400000, guid: 17f906094abc5614e84ea397e706cbdd,
+        type: 2}
     - target: {fileID: 2749592132287825911, guid: 49b062202ce45074d8c05cdeda7786df,
         type: 3}
       propertyPath: _cooldownUI
@@ -39192,6 +39198,7 @@ PrefabInstance:
     m_RemovedGameObjects:
     - {fileID: 2606461827671494603, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
     - {fileID: -156067013940870753, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
+    - {fileID: 6477753996341901030, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 4665530305536945430, guid: a9f69c317a3fea04a86e8d6739a9a1ff,
         type: 3}


### PR DESCRIPTION
## Content

The player was not able to deal damage to enemies. This was due to a missing reference.

## Changes
### Updated
`Assets/Prefabs/Player/Player_1.prefab` : Was updated, now has the scriptable object as a standard reference.
`Assets/Scenes/Levels/Entrance.unity` : Was updated with the aforementioned changes.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Load level.
2. Attack enemy using basic attack.
3. See effect.

<!-- If there is no issue, simply remove it. -->