### PR TITLE
🚑️ Hotfix abilities no longer dealing damage

### DIFF
--- a/Assets/Prefabs/VFX/Abilities/Holy Spear.prefab
+++ b/Assets/Prefabs/VFX/Abilities/Holy Spear.prefab
@@ -4943,9 +4943,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d521ea59b76f59c4785b84b7866b1b05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _damageAmount: 50
   _tags:
   - Enemy
+  _applyKnockback: 0
+  _force: 0
+  _playerStats: {fileID: 11400000, guid: 17f906094abc5614e84ea397e706cbdd, type: 2}
 --- !u!1 &2593514419796504836
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/VFX/Abilities/ShockWave.prefab
+++ b/Assets/Prefabs/VFX/Abilities/ShockWave.prefab
@@ -82,9 +82,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d521ea59b76f59c4785b84b7866b1b05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _damageAmount: 25
   _tags:
   - Enemy
+  _applyKnockback: 0
+  _force: 0
+  _playerStats: {fileID: 11400000, guid: 17f906094abc5614e84ea397e706cbdd, type: 2}
 --- !u!114 &3023905985021644160
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/VFX/Abilities/Smite.prefab
+++ b/Assets/Prefabs/VFX/Abilities/Smite.prefab
@@ -69,9 +69,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d521ea59b76f59c4785b84b7866b1b05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _damageAmount: 100
   _tags:
   - Enemy
+  _applyKnockback: 0
+  _force: 0
+  _playerStats: {fileID: 11400000, guid: 17f906094abc5614e84ea397e706cbdd, type: 2}
 --- !u!114 &4227199815311615150
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Content
This was due to the fact that the abilities use the base attack damage script, which was not anticipated during the rework.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->

### Updated
`Assets/Prefabs/VFX/Abilities/Holy Spear.prefab` : Was updated / renamed. You can add describe the changes you made here.
`Assets/Prefabs/VFX/Abilities/ShockWave.prefab` : Was updated / renamed. You can add describe the changes you made here.
`Assets/Prefabs/VFX/Abilities/Smite.prefab` : Was updated / renamed. You can add describe the changes you made here.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Open a level.
2. Use an ability.
3. Enemies take damage.