### PR TITLE
🐛 Remove duplicate enemy

### DIFF
--- a/Assets/Prefabs/Spawn System/SpawnManager.prefab
+++ b/Assets/Prefabs/Spawn System/SpawnManager.prefab
@@ -33,7 +33,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 33807815235243758}
-  - {fileID: 919829227175259400}
   - {fileID: 6129684118943416060}
   m_Father: {fileID: 2515860407542210318}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -357,80 +356,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3ad5b2fe2daecbd4980215b4e0138bd6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &6084296253936153750
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4665530305536945430}
-    m_Modifications:
-    - target: {fileID: 975690970216120944, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_Name
-      value: AxeUnit
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.68
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0d3a6b9aeadbbf74585993e25854451e, type: 3}
---- !u!4 &919829227175259400 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6389518238033058206, guid: 0d3a6b9aeadbbf74585993e25854451e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6084296253936153750}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8013049034858484690
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/Entrance.unity
+++ b/Assets/Scenes/Levels/Entrance.unity
@@ -39195,10 +39195,7 @@ PrefabInstance:
       value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 2606461827671494603, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
-    - {fileID: -156067013940870753, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
-    - {fileID: 6477753996341901030, guid: a9f69c317a3fea04a86e8d6739a9a1ff, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 4665530305536945430, guid: a9f69c317a3fea04a86e8d6739a9a1ff,
         type: 3}


### PR DESCRIPTION
## Content

Removed a duplicate instance of the enemy, solving a ton of thrown exceptions.

## Changes

### Updated
`Assets/Prefabs/Spawn System/SpawnManager.prefab` : Was updated, removed duplicate.
`Assets/Scenes/Levels/Entrance.unity` : Was updated, removed duplicate.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Open the level.
2. Press play.
3. No more errors about missing player transform.
