### PR TITLE
🐛 Fix direction of dash after attack

### DIFF
--- a/Assets/Animations/Player/Player.controller
+++ b/Assets/Animations/Player/Player.controller
@@ -258,12 +258,6 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: Dash 0
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Scripts/Player/Movement/PlayerController.cs
+++ b/Assets/Scripts/Player/Movement/PlayerController.cs
@@ -5,6 +5,7 @@ using RogueApeStudio.Crusader.HealthSystem;
 using System.Linq;
 using UnityEngine.EventSystems;
 using System.Threading;
+using System;
 
 namespace RogueApeStudio.Crusader.Player.Movement
 {
@@ -60,9 +61,14 @@ namespace RogueApeStudio.Crusader.Player.Movement
 
         private void OnDash(InputAction.CallbackContext context)
         {
-            if (!_isDashing && _dashCooldownTimer <= 0 && 
+            if (!_isDashing && _dashCooldownTimer <= 0 &&
                 _readInputs && !_animator.GetCurrentAnimatorStateInfo(0).IsName("PlayerDiveForward"))
             {
+                Vector2 inputDirection = _movementInput.ReadValue<Vector2>();
+                Vector3 movementDirection = new Vector3(inputDirection.x, 0f, inputDirection.y).normalized;
+
+                TurnPlayer(movementDirection, "dash");
+
                 _dashCooldownTimer = _dashCooldown;
                 _isDashing = true;
                 _animator.SetBool("Dash", _isDashing);
@@ -83,7 +89,7 @@ namespace RogueApeStudio.Crusader.Player.Movement
             {
                 Vector3 movementDirection = new Vector3(inputDirection.x, 0f, inputDirection.y).normalized;
 
-                TurnPlayer(movementDirection);
+                TurnPlayer(movementDirection, "run");
 
                 Vector3 _movement = _moveSpeed * Time.fixedDeltaTime * movementDirection;
                 _lastMovementDirection = movementDirection;
@@ -99,18 +105,21 @@ namespace RogueApeStudio.Crusader.Player.Movement
 
         }
 
-        private void TurnPlayer(Vector3 direction)
+        private void TurnPlayer(Vector3 direction, string action)
         {
-            if (_isDashing)
+            switch (action)
             {
-                _transform.rotation = Quaternion.LookRotation(direction);
-            }
-            else
-            {
-                float targetAngle = Mathf.Atan2(direction.x, direction.z) * Mathf.Rad2Deg;
-                Quaternion targetRotation = Quaternion.Euler(0f, targetAngle, 0f);
+                case "dash":
+                    _transform.rotation = Quaternion.LookRotation(direction);
+                    break;
+                case "run":
+                    float targetAngle = Mathf.Atan2(direction.x, direction.z) * Mathf.Rad2Deg;
+                    Quaternion targetRotation = Quaternion.Euler(0f, targetAngle, 0f);
 
-                _rb.rotation = Quaternion.RotateTowards(_rb.rotation, targetRotation, _rotationSpeed * Time.deltaTime);
+                    _rb.rotation = Quaternion.RotateTowards(_rb.rotation, targetRotation, _rotationSpeed * Time.deltaTime);
+                    break;
+                default:
+                    throw new NotImplementedException(nameof(action));
             }
         }
 


### PR DESCRIPTION
## Content

Player now dashes in the correct direction after attacking.

## Changes

### Updated
`Assets/Scripts/Player/Movement/PlayerController.cs` : Was updated. Instantly turns player again when dashing.
`Assets/Animations/Player/Player.controller` : Was updated. Removed "Dash 0" trigger since it's not used and I forgot to earlier today.

## Testing

The feature / Bugfix can be testing by following these steps:

![DashFixedAgainAgain](https://github.com/Rogue-Ape-Studios/Crusader/assets/90602424/987df510-e41e-4b06-b8a6-92731ab5a807)


Closes #182 