### PR TITLE
🐛 Properly implement stat system into basic attack

### DIFF
--- a/Assets/Scripts/Player/Combat/BasicAttack.cs
+++ b/Assets/Scripts/Player/Combat/BasicAttack.cs
@@ -32,7 +32,6 @@ namespace RogueApeStudio.Crusader.Player.Combat
 
         [Header("Attack Info")]
         [SerializeField] private int _comboCounter = 0;
-        [SerializeField] private float _attackSpeed = 5;
         [SerializeField] private float _attackWindow = 0.5f;
         [SerializeField] private bool _canAttack = true;
         [SerializeField] private bool _windowCountdown = false;
@@ -42,19 +41,20 @@ namespace RogueApeStudio.Crusader.Player.Combat
         
         [Header("Dependencies")]
         [SerializeField] private PlayerScriptableObject _playerStats;
+        private float _attackSpeed = 0;
         private CrusaderInputActions _crusaderInputActions;
         private InputAction _attackInput;
         private RaycastHit _cameraRayHit;
         private float _delay = 0f;
         private CancellationTokenSource _cancellationTokenSource;
-        private float _baseAttackSpeed;
+        private float _baseAttackSpeed => _playerStats.AttackSpeed;
 
         private void Awake()
         {
             _crusaderInputActions = new();
             _attackInput = _crusaderInputActions.Player.BasicAttack;
             _cancellationTokenSource = new CancellationTokenSource();
-            _baseAttackSpeed = _attackSpeed;
+            _attackSpeed = _baseAttackSpeed;
         }
 
         private void OnEnable()


### PR DESCRIPTION
## Content
Fixed a bug where the 1st and 3rd attack didn't track properly, alongside fixing the attack speed implementation.
Works with both the base, and severly boosted stats. This was achieved by caching the value.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->

### Updated
`Assets/Scripts/Player/Combat/BasicAttack.cs` : Was updated, fixed attack speed implementation.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Enable gizmos and select the player.
2. Play the scene.
3. See how the hitbox lights up upon each click. 

![HitboxShowcase](https://github.com/Rogue-Ape-Studios/Crusader/assets/99728206/24a86065-e7ed-4ba2-96c5-f2ec2602b1c6)


<!-- If there is no issue, simply remove it. -->
Closes #175 